### PR TITLE
Refactor jitter calculation to remove redundant statistics import and usage

### DIFF
--- a/measurement_client/client.py
+++ b/measurement_client/client.py
@@ -615,7 +615,6 @@ class SintraMeasurementClient:
                         if len(rtts) > 1:
                             from statistics import stdev
                             jitters.append(stdev([float(rtt) for rtt in rtts]))
-                            jitters.append(statistics.stdev([float(rtt) for rtt in rtts]))
                         else:
                             jitters.append(0.0)
                 

--- a/measurement_client/fetch_config.yaml
+++ b/measurement_client/fetch_config.yaml
@@ -2,9 +2,7 @@
 # It specifies the measurement IDs to fetch and the settings for fetching.
 # Multiple measurement IDs can be specified, and the fetch settings include the limit and format for the results.
 measurement_ids:
-  - 121070292
-  - 121070392
-  - 121069316
+  - 127745569
 
 # Fetch settings for the measurement results
 # The limit specifies the maximum number of results to fetch, and the format specifies the output format


### PR DESCRIPTION
This pull request makes a minor configuration update and a small code cleanup. The configuration file now fetches a single measurement ID instead of multiple, and redundant code for calculating jitter has been removed.