### PR TITLE
feat: implement all 11 proposed enhancements

### DIFF
--- a/event_manager/anomaly_types.py
+++ b/event_manager/anomaly_types.py
@@ -1,47 +1,52 @@
 ANOMALY_TYPES = {
     "latency_spike": {
-        "description": "RTT (Round Trip Time) exceeds a threshold (e.g., > 250 ms) or spikes suddenly",
-        "measurement_type": "ping",
+        "description": "RTT (Round Trip Time) exceeds a threshold (e.g., > 250 ms) or spikes suddenly",
+        "measurement_type": ["ping"],
         "latency_related": True
     },
     "packet_loss": {
-        "description": "% of lost packets > threshold (e.g., 5–10%)",
-        "measurement_type": "ping",
+        "description": "% of lost packets > threshold (e.g., 5-10%)",
+        "measurement_type": ["ping"],
         "latency_related": False
     },
     "unreachable_host": {
         "description": "100% packet loss, host not reachable, no ping replies",
-        "measurement_type": "ping, traceroute",
+        "measurement_type": ["ping", "traceroute"],
         "latency_related": False
     },
     "route_change": {
         "description": "Traceroute path is different than baseline path (hop IPs or count changed)",
-        "measurement_type": "traceroute",
+        "measurement_type": ["traceroute"],
         "latency_related": False
     },
     "path_flapping": {
         "description": "Route changes frequently (e.g., unstable topology)",
-        "measurement_type": "traceroute",
+        "measurement_type": ["traceroute"],
         "latency_related": False
     },
     "geo_anomaly": {
         "description": "Far probe suddenly has better latency than near one (suspicious routing)",
-        "measurement_type": "ping",
+        "measurement_type": ["ping"],
         "latency_related": True
     },
     "jitter_spike": {
         "description": "High variation in RTTs (instability, not necessarily high latency)",
-        "measurement_type": "ping",
+        "measurement_type": ["ping"],
         "latency_related": True
     },
     "outlier_probe_latency": {
         "description": "Only some probes report high delay (not the majority)",
-        "measurement_type": "ping",
+        "measurement_type": ["ping"],
         "latency_related": True
     },
     "outlier_probe_loss": {
         "description": "Only some probes report high loss (not the majority)",
-        "measurement_type": "ping",
+        "measurement_type": ["ping"],
         "latency_related": False
+    },
+    "correlated_routing_event": {
+        "description": "Latency spike correlated with a route change on the same probe (probable routing cause)",
+        "measurement_type": ["ping", "traceroute"],
+        "latency_related": True
     }
 }

--- a/event_manager/config.json
+++ b/event_manager/config.json
@@ -8,11 +8,17 @@
     "geo_anomaly_margin_ms": 50.0,
     "path_flapping_window": 3
   },
+  "target_thresholds": {},
   "detection": {
     "enable_outlier_detection": true,
     "enable_geo_anomaly_detection": true,
     "enable_adaptive_baseline": true
   },
   "level": "INFO",
-  "include_debug_info": false
+  "include_debug_info": false,
+  "webhook": {
+    "enabled": false,
+    "url": "",
+    "timeout_seconds": 10
+  }
 }

--- a/event_manager/eventmanager.py
+++ b/event_manager/eventmanager.py
@@ -1,8 +1,12 @@
 import os
+import re
 import json
+import tempfile
+import requests
 from pathlib import Path
-from datetime import datetime
-from typing import Dict, List, Any, Optional
+from datetime import datetime, timezone
+from typing import Dict, List, Any, Optional, Tuple
+from urllib.parse import urlparse
 from measurement_client.logger import logger
 from .anomaly_types import ANOMALY_TYPES
 from .anomaly_utils import calculate_jitter, is_outlier, geo_anomaly_check
@@ -92,19 +96,27 @@ class SintraEventManager:
             
         processed_count = 0
         error_count = 0
+        all_results = []  # Collect (measurement_id, events) for post-analysis webhook dispatch
         
         for result_file in result_files:
             try:
-                events = self._analyze_single_file(result_file)
+                measurement_id, events = self._analyze_single_file(result_file)
                 processed_count += 1
+                if measurement_id and events:
+                    all_results.append((measurement_id, events))
                 logger.debug(f"Processed {result_file.name}: {len(events)} events detected")
             except Exception as e:
                 error_count += 1
                 logger.error(f"Failed to analyze {result_file.name}: {e}")
                 
         logger.info(f"Analysis complete: {processed_count} files processed, {error_count} errors")
+        
+        # Send webhook alerts after all analysis is complete (not during save)
+        for measurement_id, events in all_results:
+            self.send_webhook_alert(measurement_id, events)
 
-    def _analyze_single_file(self, result_file: Path) -> List[Dict[str, Any]]:
+    def _analyze_single_file(self, result_file: Path) -> Tuple[Optional[str], List[Dict[str, Any]]]:
+        """Analyze a single measurement file. Returns (measurement_id, events)."""
         try:
             with open(result_file, "r") as f:
                 data = json.load(f)
@@ -115,8 +127,9 @@ class SintraEventManager:
         measurement_id = data.get("measurement_id")
         if not measurement_id:
             logger.warning(f"No measurement_id found in {result_file}")
-            return []
+            return None, []
             
+        measurement_id = str(measurement_id)
         events = self.analyze_measurement(data)
         self.save_events(measurement_id, events)
         
@@ -125,11 +138,11 @@ class SintraEventManager:
         else:
             logger.debug(f"No anomalies found for measurement {measurement_id}")
             
-        return events
+        return measurement_id, events
 
     def analyze_measurement(self, data: Dict[str, Any]) -> List[Dict[str, Any]]:
         events = []
-        timestamp = datetime.utcnow().isoformat() + "Z"
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         
         # Initialize data collectors
         probe_data = self._collect_probe_data(data)
@@ -138,6 +151,10 @@ class SintraEventManager:
         events.extend(self._detect_outlier_anomalies(probe_data, timestamp))
         events.extend(self._detect_threshold_anomalies(probe_data, timestamp))
         events.extend(self._detect_routing_anomalies(probe_data, timestamp))
+        
+        # Cross-correlate ping and traceroute anomalies using a snapshot
+        # to avoid coupling with future changes in _correlate_events return semantics
+        events.extend(self._correlate_events(list(events), timestamp))
         
         logger.debug(f"Detected {len(events)} total anomalies for measurement {data.get('measurement_id')}")
         return events
@@ -158,6 +175,9 @@ class SintraEventManager:
             probe_id = result.get("probe_id")
             if not probe_id:
                 continue
+            # Normalize probe_id to string to prevent silent key mismatches
+            # (RIPE Atlas may return probe IDs as int or str)
+            probe_id = str(probe_id)
                 
             target_addr = result.get("target_address") or result.get("target")
             probe_data['targets'][probe_id] = target_addr
@@ -197,20 +217,81 @@ class SintraEventManager:
         previous_hops = self._get_and_update_baseline_hops(probe_id, target_addr, hop_ips)
         probe_data['baseline_hops'][probe_id] = previous_hops
 
+    @staticmethod
+    def _sanitize_filename(value: str) -> str:
+        """Sanitize a value for safe use in filenames.
+        
+        Removes path separators, special chars, and consecutive dots
+        to prevent path traversal or ambiguous filenames.
+        """
+        sanitized = re.sub(r'[^a-zA-Z0-9._-]', '_', str(value))
+        # Collapse consecutive dots to prevent path-traversal-looking names
+        sanitized = re.sub(r'\.{2,}', '.', sanitized)
+        return sanitized.strip('.')
+
     def _get_and_update_baseline_rtt(self, probe_id: str, target_addr: str, 
                                     current_rtt: Optional[float]) -> Optional[float]:
-        baseline_file = self.baseline_dir / f"ping_{probe_id}_{target_addr}.json"
+        """Get baseline RTT using a rolling average of the last N measurements.
+        
+        Stores the last 10 RTT values per probe-target pair and uses their
+        average as the baseline. This smooths out temporary spikes and dips,
+        giving a more stable and realistic picture of normal latency.
+        
+        The baseline is computed from values stored *before* the current RTT
+        is appended, so min_samples + 1 total calls are needed before a
+        baseline is returned (e.g., 4 calls when min_samples=3).
+        
+        Note: Spike values are still stored in the rolling window, which may
+        drag the baseline upward during sustained anomalies. The window size
+        (default 10) limits this drift, and values age out as new data arrives.
+        """
+        if target_addr is None:
+            logger.debug(f"Skipping baseline RTT for probe {probe_id}: target_addr is None")
+            return None
+
+        safe_probe = self._sanitize_filename(probe_id)
+        safe_target = self._sanitize_filename(target_addr)
+        baseline_file = self.baseline_dir / f"ping_{safe_probe}_{safe_target}.json"
         baseline_rtt = None
+        rolling_window_size = 10
+        min_samples = 3  # Require at least 3 samples for a reliable baseline
         
         try:
+            rtts = []
             if baseline_file.exists():
                 with open(baseline_file, "r") as bf:
                     baseline_data = json.load(bf)
-                    baseline_rtt = baseline_data.get("avg_rtt")
+                    rtts = baseline_data.get("rtts", [])
+                    # Fallback: migrate from old single-value format
+                    if not rtts and baseline_data.get("avg_rtt") is not None:
+                        rtts = [baseline_data["avg_rtt"]]
+                    
+                    # Only use baseline if we have enough samples
+                    if len(rtts) >= min_samples:
+                        baseline_rtt = sum(rtts) / len(rtts)
             
             if current_rtt is not None:
-                with open(baseline_file, "w") as bf:
-                    json.dump({"avg_rtt": current_rtt}, bf)
+                rtts.append(current_rtt)
+                # Keep only the last N values
+                if len(rtts) > rolling_window_size:
+                    rtts = rtts[-rolling_window_size:]
+                
+                # Write atomically via temp file to prevent corruption on interruption
+                baseline_data = {
+                    "rtts": rtts,
+                    "avg_rtt": sum(rtts) / len(rtts)  # Kept for external readers/debugging
+                }
+                fd, tmp_path = tempfile.mkstemp(dir=str(self.baseline_dir), suffix=".tmp")
+                try:
+                    with os.fdopen(fd, "w") as bf:
+                        json.dump(baseline_data, bf)
+                    os.replace(tmp_path, str(baseline_file))
+                except Exception:
+                    try:
+                        os.unlink(tmp_path)
+                    except FileNotFoundError:
+                        pass
+                    raise
                     
         except (json.JSONDecodeError, IOError) as e:
             logger.warning(f"Failed to handle baseline RTT for {probe_id}->{target_addr}: {e}")
@@ -219,7 +300,14 @@ class SintraEventManager:
 
     def _get_and_update_baseline_hops(self, probe_id: str, target_addr: str,
                                      current_hops: List[str]) -> Optional[List[str]]:
-        baseline_file = self.baseline_dir / f"traceroute_{probe_id}_{target_addr}.json"
+        """Get previous traceroute hops and store current ones as the new baseline."""
+        if target_addr is None:
+            logger.debug(f"Skipping baseline hops for probe {probe_id}: target_addr is None")
+            return None
+
+        safe_probe = self._sanitize_filename(probe_id)
+        safe_target = self._sanitize_filename(target_addr)
+        baseline_file = self.baseline_dir / f"traceroute_{safe_probe}_{safe_target}.json"
         previous_hops = None
         
         try:
@@ -228,8 +316,18 @@ class SintraEventManager:
                     baseline_data = json.load(bf)
                     previous_hops = baseline_data.get("hop_ips")
             
-            with open(baseline_file, "w") as bf:
-                json.dump({"hop_ips": current_hops}, bf)
+            # Write atomically via temp file to prevent corruption on interruption
+            fd, tmp_path = tempfile.mkstemp(dir=str(self.baseline_dir), suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w") as bf:
+                    json.dump({"hop_ips": current_hops}, bf)
+                os.replace(tmp_path, str(baseline_file))
+            except Exception:
+                    try:
+                        os.unlink(tmp_path)
+                    except FileNotFoundError:
+                        pass
+                    raise
                 
         except (json.JSONDecodeError, IOError) as e:
             logger.warning(f"Failed to handle baseline hops for {probe_id}->{target_addr}: {e}")
@@ -246,7 +344,9 @@ class SintraEventManager:
         outlier_factor = self.config["thresholds"]["outlier_factor"]
         
         for probe_id, latency in probe_data['latencies'].items():
-            if latency and is_outlier(latency, probe_data['latencies'].values(), outlier_factor):
+            # Filter None from population to avoid arithmetic errors in is_outlier
+            valid_latencies = [v for v in probe_data['latencies'].values() if v is not None]
+            if latency is not None and is_outlier(latency, valid_latencies, outlier_factor):
                 events.append(self._create_event(
                     timestamp, "outlier_probe_latency", probe_id,
                     probe_data['targets'][probe_id], "ping_rtt_ms",
@@ -254,8 +354,9 @@ class SintraEventManager:
                 ))
         
         for probe_id, loss in probe_data['losses'].items():
-            if (loss and loss > 5.0 and 
-                is_outlier(loss, probe_data['losses'].values(), outlier_factor)):
+            valid_losses = [v for v in probe_data['losses'].values() if v is not None]
+            if (loss is not None and loss > 5.0 and 
+                is_outlier(loss, valid_losses, outlier_factor)):
                 events.append(self._create_event(
                     timestamp, "outlier_probe_loss", probe_id,
                     probe_data['targets'][probe_id], "ping_loss_pct",
@@ -268,33 +369,50 @@ class SintraEventManager:
                                    timestamp: str) -> List[Dict[str, Any]]:
         events = []
         thresholds = self.config["thresholds"]
+        target_thresholds = self.config.get("target_thresholds", {})
         
         for probe_id in probe_data['targets']:
             target_addr = probe_data['targets'][probe_id]
             
-            # Latency spike detection
+            # Use per-target threshold if configured, otherwise fall back to global
+            target_config = target_thresholds.get(target_addr, {})
+            latency_threshold = target_config.get(
+                "latency_spike_ms", thresholds["latency_spike_ms"]
+            )
+            
+            # Latency spike detection (emit at most one per probe — take highest violation)
             latency = probe_data['latencies'].get(probe_id)
-            if latency:
-                # Static threshold
-                if latency > thresholds["latency_spike_ms"]:
-                    events.append(self._create_event(
-                        timestamp, "latency_spike", probe_id, target_addr,
-                        "ping_rtt_ms", latency, thresholds["latency_spike_ms"],
-                        "ms", "warning"
-                    ))
+            if latency is not None:
+                spike_event = None
                 
-                baseline_rtt = probe_data['baseline_rtts'].get(probe_id)
-                if (baseline_rtt and 
-                    latency > baseline_rtt * thresholds["latency_spike_multiplier"]):
-                    events.append(self._create_event(
+                # Static threshold (per-target or global)
+                if latency > latency_threshold:
+                    spike_event = self._create_event(
                         timestamp, "latency_spike", probe_id, target_addr,
-                        "ping_rtt_ms", latency, baseline_rtt * thresholds["latency_spike_multiplier"],
+                        "ping_rtt_ms", latency, latency_threshold,
                         "ms", "warning"
-                    ))
+                    )
+                
+                # Multiplier-based threshold (overrides static if also triggered)
+                baseline_rtt = probe_data['baseline_rtts'].get(probe_id)
+                multiplier_threshold = (
+                    baseline_rtt * thresholds["latency_spike_multiplier"]
+                    if baseline_rtt is not None else None
+                )
+                if (multiplier_threshold is not None and
+                    latency > multiplier_threshold):
+                    spike_event = self._create_event(
+                        timestamp, "latency_spike", probe_id, target_addr,
+                        "ping_rtt_ms", latency, multiplier_threshold,
+                        "ms", "warning"
+                    )
+                
+                if spike_event:
+                    events.append(spike_event)
             
             # Packet loss detection
             loss = probe_data['losses'].get(probe_id)
-            if loss and loss > thresholds["packet_loss_percentage"]:
+            if loss is not None and loss > thresholds["packet_loss_percentage"]:
                 events.append(self._create_event(
                     timestamp, "packet_loss", probe_id, target_addr,
                     "ping_loss_pct", loss, thresholds["packet_loss_percentage"],
@@ -302,7 +420,7 @@ class SintraEventManager:
                 ))
             
             # Unreachable host detection
-            if loss and loss == 100.0:
+            if loss is not None and loss == 100.0:
                 events.append(self._create_event(
                     timestamp, "unreachable_host", probe_id, target_addr,
                     "reachability", 0, 1, "reachable_flag", "critical"
@@ -310,7 +428,7 @@ class SintraEventManager:
             
             # Jitter spike detection
             jitter = probe_data['jitters'].get(probe_id)
-            if jitter and jitter > thresholds["jitter_spike_ms"]:
+            if jitter is not None and jitter > thresholds["jitter_spike_ms"]:
                 events.append(self._create_event(
                     timestamp, "jitter_spike", probe_id, target_addr,
                     "ping_jitter_ms", jitter, thresholds["jitter_spike_ms"],
@@ -362,6 +480,51 @@ class SintraEventManager:
         
         return events
 
+    def _correlate_events(self, events: List[Dict[str, Any]], 
+                         timestamp: str) -> List[Dict[str, Any]]:
+        """Cross-correlate ping and traceroute anomalies from the same probe.
+        
+        If a latency spike is detected at the same time as a route change from
+        the same probe to the same target, adds a 'correlated_routing_event'
+        alongside the existing events to flag the probable root cause.
+        The original latency_spike and route_change events are kept as-is.
+        """
+        correlated = []
+        
+        # Group events by (probe_id, target) using tuple keys to avoid
+        # string concatenation collisions. Defensive: skip correlated events
+        # in case this function is ever called iteratively/idempotently.
+        groups: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        for event in events:
+            if event.get("anomaly") == "correlated_routing_event":
+                continue
+            key = (str(event.get('probe_id', '')), str(event.get('target', '')))
+            if key not in groups:
+                groups[key] = {"anomalies": [], "event_refs": [], 
+                              "probe_id": key[0], "target": key[1]}
+            groups[key]["anomalies"].append(event.get("anomaly"))
+            groups[key]["event_refs"].append(event)
+        
+        # Check for latency_spike + route_change in the same group
+        for key, group in groups.items():
+            anomaly_types = set(group["anomalies"])
+            if "latency_spike" in anomaly_types and "route_change" in anomaly_types:
+                probe_id = group["probe_id"]
+                target = group["target"]
+                
+                correlated_event = self._create_event(
+                    timestamp, "correlated_routing_event", probe_id, target,
+                    "correlation", None, None, "", "warning"
+                )
+                correlated_event["description"] = (
+                    "Latency spike likely caused by route change detected on the same probe"
+                )
+                correlated_event["correlated_anomalies"] = ["latency_spike", "route_change"]
+                correlated.append(correlated_event)
+                logger.debug(f"Correlated latency_spike + route_change for probe {probe_id} -> {target}")
+        
+        return correlated
+
     def _create_event(self, timestamp: str, anomaly: str, probe_id: str,
                      target: str, metric: str, value: Any, threshold: Any,
                      units: str, severity: str) -> Dict[str, Any]:
@@ -385,7 +548,7 @@ class SintraEventManager:
             
             output_data = {
                 "measurement_id": measurement_id,
-                "analysis_timestamp": datetime.utcnow().isoformat() + "Z",
+                "analysis_timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
                 "events": events,
                 "analysis": analysis
             }
@@ -467,4 +630,89 @@ class SintraEventManager:
         Send events to POX controller (to be implemented).
         """
         logger.info(f"Sending events for measurement {measurement_id} to POX controller (placeholder)")
+
+    def send_webhook_alert(self, measurement_id: str, events: List[Dict[str, Any]]) -> None:
+        """Send alert notifications to a configured webhook URL.
+        
+        Sends a POST request with JSON payload containing measurement ID,
+        anomaly types, severity, and affected probes. Only events with
+        'critical' or 'warning' severity are included in the payload;
+        info-level events are filtered out.
+        
+        Compatible with Slack, Microsoft Teams, Discord, PagerDuty, or
+        any custom endpoint.
+        
+        Note: This runs synchronously. For high-throughput batch analysis,
+        consider running detection and alerting in separate steps.
+        """
+        webhook_config = self.config.get("webhook", {})
+        
+        if not webhook_config.get("enabled", False):
+            logger.debug("Webhook alerts are disabled")
+            return
+        
+        webhook_url = webhook_config.get("url", "")
+        if not webhook_url:
+            logger.warning("Webhook URL is not configured")
+            return
+        
+        # Validate URL scheme and reject insecure HTTP unless explicitly allowed
+        parsed = urlparse(webhook_url)
+        if parsed.scheme not in ("https", "http"):
+            logger.error(f"Invalid webhook URL scheme '{parsed.scheme}': {webhook_url}. Must be https:// or http://")
+            return
+        if parsed.scheme == "http":
+            if not webhook_config.get("allow_insecure_http", False):
+                logger.error(
+                    "Webhook URL uses plain HTTP and insecure delivery is disabled. "
+                    "Use https:// or set webhook.allow_insecure_http=true to opt in."
+                )
+                return
+            logger.warning("Webhook URL uses plain HTTP; alert payloads will be sent unencrypted")
+        
+        timeout = webhook_config.get("timeout_seconds", 10)
+        
+        # Filter for critical/warning events worth alerting on
+        alert_events = [e for e in events if e.get("severity") in ("critical", "warning")]
+        if not alert_events:
+            logger.debug(f"No alertable events for measurement {measurement_id}")
+            return
+        
+        # Build payload
+        payload = {
+            "measurement_id": measurement_id,
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "total_anomalies": len(alert_events),
+            "anomalies": []
+        }
+        
+        for event in alert_events:
+            payload["anomalies"].append({
+                "type": event.get("anomaly"),
+                "probe_id": event.get("probe_id"),
+                "target": event.get("target"),
+                "severity": event.get("severity"),
+                "value": event.get("value"),
+                "threshold": event.get("threshold"),
+                "units": event.get("units", "")
+            })
+        
+        try:
+            response = requests.post(
+                webhook_url,
+                json=payload,
+                timeout=timeout,
+                headers={"Content-Type": "application/json"}
+            )
+            
+            if response.status_code < 300:
+                logger.info(f"Webhook alert sent for measurement {measurement_id}: {len(alert_events)} anomalies")
+            else:
+                logger.warning(
+                    f"Webhook returned status {response.status_code} for measurement {measurement_id}: "
+                    f"{response.text[:200]}"
+                )
+                
+        except requests.RequestException as e:
+            logger.error(f"Failed to send webhook alert for measurement {measurement_id}: {e}")
 

--- a/measurement_client/client.py
+++ b/measurement_client/client.py
@@ -2,7 +2,7 @@ import os
 import json
 import yaml
 import argparse
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 from dotenv import load_dotenv
@@ -17,6 +17,7 @@ from measurement_client.processors import (
 )
 from collections import defaultdict
 from statistics import mean, median
+import time
 import requests
 
 class SintraMeasurementClient:
@@ -48,6 +49,7 @@ class SintraMeasurementClient:
             
             self.create_config = None
             self.fetch_config = None
+            self.since_timestamp = None
             
             logger.info("SintraMeasurementClient initialized successfully")
             
@@ -142,10 +144,12 @@ class SintraMeasurementClient:
             if not isinstance(measurement_id, int):
                 raise ValueError(f"Invalid measurement_id: {measurement_id}. Must be an integer")
 
-    # This method creates measurements based on the loaded configuration.
-    # It processes each measurement configuration, creates the measurement,
-    logger.info("Creating measurements...")
     def create_measurements(self):
+        """Create measurements based on the loaded configuration.
+        
+        Processes each measurement configuration, creates the measurement,
+        and saves the results.
+        """
         logger.info("Creating measurements...")
         
         try:
@@ -197,7 +201,7 @@ class SintraMeasurementClient:
                 return False
             
             # Set timing parameters
-            start_time = datetime.utcnow() + timedelta(minutes=1)
+            start_time = datetime.now(timezone.utc) + timedelta(minutes=1)
             duration_hours = measurement_config.get('duration_hours', 1)
             stop_time = start_time + timedelta(hours=duration_hours)
 
@@ -379,6 +383,17 @@ class SintraMeasurementClient:
                 if 'probe_ids' in fetch_settings:
                     kwargs['probe_ids'] = fetch_settings['probe_ids']
             
+            # Apply --since time filter (overrides config time window)
+            if self.since_timestamp:
+                kwargs['start'] = self.since_timestamp
+                # --since should be the sole time constraint; remove any configured stop filter
+                if 'stop' in kwargs:
+                    logger.debug(
+                        f"Removing stop filter because --since was provided: stop={kwargs['stop']}, start={kwargs['start']}"
+                    )
+                    del kwargs['stop']
+                logger.debug(f"Applying --since filter: start={self.since_timestamp}")
+            
             # Execute the fetch request
             is_success, results = AtlasResultsRequest(**kwargs).create()
             
@@ -402,12 +417,61 @@ class SintraMeasurementClient:
             logger.error(f"Exception fetching measurement {measurement_id}: {e}")
             return False
 
+    def _request_with_backoff(self, url: str, max_retries: int = 3, 
+                              base_delay: float = 2.0) -> requests.Response:
+        """Make an HTTP GET request with exponential backoff on transient failures.
+        
+        Retries on HTTP 429 (rate limited) and 5xx (server error) responses with
+        exponential backoff. Honors the Retry-After header when present on 429
+        responses.
+        
+        Returns a successful Response on 2xx/3xx. Always raises
+        requests.RequestException on final failure (never returns None).
+        """
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.get(url, timeout=30)
+                
+                # Retry on rate limiting (429) or server errors (5xx)
+                if response.status_code == 429 or response.status_code >= 500:
+                    if attempt < max_retries:
+                        # Honor Retry-After header if present (common on RIPE Atlas 429s).
+                        # Note: RFC 7231 also allows HTTP-date format; we only handle
+                        # integer seconds here and fall back to exponential delay otherwise.
+                        retry_after = response.headers.get("Retry-After")
+                        if retry_after and retry_after.isdigit():
+                            delay = min(int(retry_after), 60)  # Cap at 60s
+                        else:
+                            delay = base_delay * (2 ** attempt)
+                        logger.warning(
+                            f"HTTP {response.status_code} from API. "
+                            f"Retrying in {delay}s (attempt {attempt + 1}/{max_retries})"
+                        )
+                        time.sleep(delay)
+                        continue
+                    # Final retry exhausted
+                    logger.error(f"HTTP {response.status_code} after {max_retries} retries: {url}")
+                
+                # Raises for any 4xx/5xx (including final retry)
+                response.raise_for_status()
+                return response
+                
+            except requests.RequestException as e:
+                if attempt < max_retries:
+                    delay = base_delay * (2 ** attempt)
+                    logger.warning(f"Request failed: {e}. Retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+                    time.sleep(delay)
+                    continue
+                raise
+        
+        # All paths above either return or raise; this is unreachable
+        assert False, f"Unreachable: request loop for {url} exited without return or raise"
+
     def _get_measurement_info(self, measurement_id: int) -> Optional[Dict[str, Any]]:
         """Get measurement information from RIPE Atlas API."""
         try:
             measurement_url = f"{self.base_url}/measurements/{measurement_id}/"
-            response = requests.get(measurement_url)
-            response.raise_for_status()
+            response = self._request_with_backoff(measurement_url)
             return response.json()
         except requests.RequestException as e:
             logger.error(f"Error getting measurement info for {measurement_id}: {e}")
@@ -420,7 +484,7 @@ class SintraMeasurementClient:
             "measurement_type": measurement_info.get("type"),
             "target": measurement_info.get("target"),
             "description": measurement_info.get("description"),
-            "fetched_at": datetime.utcnow().isoformat(),
+            "fetched_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             "results_count": len(results),
             "summary": {
                 "total_probes": len(set(result.get("prb_id") for result in results)),
@@ -520,8 +584,7 @@ class SintraMeasurementClient:
                 probe_ids_str = ','.join(map(str, batch))
                 probe_url = f"{self.base_url}/probes/?id__in={probe_ids_str}"
                 
-                response = requests.get(probe_url)
-                response.raise_for_status()
+                response = self._request_with_backoff(probe_url)
                 probe_data = response.json()
                 
                 # Process batch results
@@ -668,7 +731,7 @@ class SintraMeasurementClient:
             "measurement_id": measurement_id,
             "target": target,
             "type": config.get('type', 'ping'),
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             "config": config
         }
         
@@ -694,130 +757,7 @@ class SintraMeasurementClient:
                     logger.warning(f"Error reading measurement info from {info_file}: {e}")
                     continue
         return measurement_ids
-    
-    # This method processes the results fetched from the RIPE Atlas API
-    # It takes the results and measurement_id as input and returns a processed dictionary
-    def _process_results(self, results, measurement_id):
-        processed = {
-            "measurement_id": measurement_id,
-            "fetched_at": datetime.utcnow().isoformat(),
-            "results_count": len(results),
-            "results": []
-        }
-        
-        for result in results:
-            processed_result = {
-                "probe_id": result.get("prb_id"),
-                "timestamp": result.get("timestamp"),
-                "from": result.get("from"),
-                "target": result.get("dst_name"),
-            }
-            
-            if "result" in result:
-                ping_results = result["result"]
-                rtts = [r.get("rtt") for r in ping_results if r.get("rtt")]
-                processed_result.update({
-                    "packet_loss": len([r for r in ping_results if r.get("x")]) / len(ping_results) * 100,
-                    "avg_latency": sum(rtts) / len(rtts) if rtts else None,
-                    "min_latency": min(rtts) if rtts else None,
-                    "max_latency": max(rtts) if rtts else None,
-                    "packets_sent": len(ping_results),
-                    "packets_received": len(rtts)
-                })
-            
-            if "result" in result and any("hop" in str(result).lower() for r in result.get("result", [])):
-                processed_result["traceroute_hops"] = result.get("result", [])
-            
-            processed["results"].append(processed_result)
-        
-        return processed
-    
-    # This method processes all results fetched from the RIPE Atlas API
-    # It takes the results and measurement_id as input and returns a processed dictionary
-    def _process_all_results(self, results, measurement_id):
-        processed = {
-            "measurement_id": measurement_id,
-            "fetched_at": datetime.utcnow().isoformat(),
-            "results_count": len(results),
-            "summary": {
-                "total_probes": len(set(result.get("prb_id") for result in results)),
-                "total_results": len(results),
-                "time_range": {
-                    "start": min(result.get("timestamp", 0) for result in results) if results else None,
-                    "end": max(result.get("timestamp", 0) for result in results) if results else None
-                }
-            },
-            "results": []
-        }
 
-        probe_results = {}
-        for result in results:
-            probe_id = result.get("prb_id")
-            measurement_type = result.get("type")
-            if probe_id not in probe_results:
-                probe_results[probe_id] = {
-                    "measurement_type": measurement_type,
-                    "measurement_id": measurement_id,
-                    "probe_id": probe_id,
-                    "source_address": result.get("from"),
-                    "target_address": result.get("dst_addr"),
-                    "target_name": result.get("dst_name"),
-                    "timestamp": datetime.utcfromtimestamp(result.get("timestamp", 0)).isoformat() if result.get("timestamp") else None,
-                    "firmware_version": result.get("fw"),
-                    "probe_asn": result.get("from_asn"),
-                    "probe_country": result.get("country_code"),
-                    "protocol": result.get("proto", "ICMP"),
-                    "address_family": result.get("af", 4)
-                }
-                # Initialize aggregation fields
-                if measurement_type == "ping":
-                    probe_results[probe_id].update({
-                        "latency_stats": {"rtts": [], "avg": None, "min": None, "max": None},
-                        "packet_loss_percentage": None,
-                        "packets_sent": 0,
-                        "packets_received": 0
-                    })
-                elif measurement_type == "traceroute":
-                    probe_results[probe_id].update({
-                        "hops": [],
-                        "hops_count": 0
-                    })
-
-            # Aggregate ping results
-            if measurement_type == "ping" and "result" in result:
-                ping_results = result["result"]
-                rtts = [r.get("rtt") for r in ping_results if r.get("rtt") is not None]
-                probe_results[probe_id]["latency_stats"]["rtts"].extend(rtts)
-                probe_results[probe_id]["packets_sent"] += len(ping_results)
-                probe_results[probe_id]["packets_received"] += len(rtts)
-                loss_count = len([r for r in ping_results if r.get("x")])
-                # Calculate packet loss percentage for this batch
-                if probe_results[probe_id]["packets_sent"] > 0:
-                    probe_results[probe_id]["packet_loss_percentage"] = (
-                        loss_count / probe_results[probe_id]["packets_sent"] * 100
-                    )
-            # Aggregate traceroute results
-            elif measurement_type == "traceroute" and "result" in result:
-                hops = result.get("result", [])
-                probe_results[probe_id]["hops"] = hops
-                probe_results[probe_id]["hops_count"] = len(hops)
-
-        # Finalize latency stats for ping
-        for probe_id, res in probe_results.items():
-            if res.get("measurement_type") == "ping":
-                rtts = res["latency_stats"]["rtts"]
-                if rtts:
-                    res["latency_stats"]["avg"] = sum(rtts) / len(rtts)
-                    res["latency_stats"]["min"] = min(rtts)
-                    res["latency_stats"]["max"] = max(rtts)
-                else:
-                    res["latency_stats"]["avg"] = None
-                    res["latency_stats"]["min"] = None
-                    res["latency_stats"]["max"] = None
-
-        processed["results"] = list(probe_results.values())
-        return processed
-    
     # This method analyzes the traceroute path and returns a summary of the hops
     # It takes the hops as input and returns a dictionary with hop details.
     def _analyze_traceroute_path(self, hops):
@@ -1055,8 +995,7 @@ class SintraMeasurementClient:
         """Get probe information including country code."""
         try:
             probe_url = f"{self.base_url}/probes/{probe_id}/"
-            response = requests.get(probe_url)
-            response.raise_for_status()
+            response = self._request_with_backoff(probe_url)
             probe_data = response.json()
             
             return {
@@ -1136,7 +1075,11 @@ class SintraMeasurementClient:
         return country_map.get(country_code, country_code)
 
     def _process_measurement_result(self, result: Dict, measurement_info: Dict, probe_info: Dict) -> Optional[Dict[str, Any]]:
-        """Process a single measurement result with probe information."""
+        """Process a single measurement result with probe information.
+        
+        Uses the canonical _process_ping_data and _process_traceroute_data methods
+        to avoid duplicate processing logic.
+        """
         try:
             measurement_type = measurement_info.get("type")
             processed_result = {
@@ -1149,51 +1092,32 @@ class SintraMeasurementClient:
                 "target": measurement_info.get("target")
             }
             
-            if measurement_type == "ping":
-                processed_result.update(self._process_ping_result(result))
-            elif measurement_type == "traceroute":
-                processed_result.update(self._process_traceroute_result(result))
+            if measurement_type == "ping" and "result" in result:
+                ping_results = result["result"]
+                rtts = [r.get("rtt") for r in ping_results if r.get("rtt") is not None]
+                processed_result.update({
+                    "latency_stats": {
+                        "rtts": rtts,
+                        "avg": sum(rtts) / len(rtts) if rtts else None,
+                        "min": min(rtts) if rtts else None,
+                        "max": max(rtts) if rtts else None
+                    },
+                    "packet_loss_percentage": len([r for r in ping_results if r.get("x")]) / len(ping_results) * 100 if ping_results else 0,
+                    "packets_sent": len(ping_results),
+                    "packets_received": len(rtts)
+                })
+            elif measurement_type == "traceroute" and "result" in result:
+                hops = result.get("result", [])
+                processed_result.update({
+                    "hops": hops,
+                    "hops_count": len(hops)
+                })
             
             return processed_result
             
         except Exception as e:
             logger.warning(f"Error processing result for probe {result.get('prb_id')}: {e}")
             return None
-
-    def _process_ping_result(self, result: Dict) -> Dict[str, Any]:
-        """Process ping measurement result."""
-        ping_data = {}
-        
-        if "result" in result:
-            ping_results = result["result"]
-            rtts = [r.get("rtt") for r in ping_results if r.get("rtt") is not None]
-            
-            ping_data.update({
-                "latency_stats": {
-                    "rtts": rtts,
-                    "avg": sum(rtts) / len(rtts) if rtts else None,
-                    "min": min(rtts) if rtts else None,
-                    "max": max(rtts) if rtts else None
-                },
-                "packet_loss_percentage": len([r for r in ping_results if r.get("x")]) / len(ping_results) * 100 if ping_results else 0,
-                "packets_sent": len(ping_results),
-                "packets_received": len(rtts)
-            })
-        
-        return ping_data
-
-    def _process_traceroute_result(self, result: Dict) -> Dict[str, Any]:
-        """Process traceroute measurement result."""
-        traceroute_data = {}
-        
-        if "result" in result:
-            hops = result.get("result", [])
-            traceroute_data.update({
-                "hops": hops,
-                "hops_count": len(hops)
-            })
-        
-        return traceroute_data
 
 def main():
     # This is the main entry point for the Sintra Measurement Client

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML>=6.0.3
 python-dotenv>=1.2.2
 matplotlib>=3.10.9
 seaborn>=0.13.2
+pytest>=7.0.0

--- a/sintra.py
+++ b/sintra.py
@@ -2,7 +2,9 @@ import argparse
 import sys
 import json
 import logging
+import re
 from pathlib import Path
+from datetime import datetime, timedelta, timezone
 from measurement_client.client import SintraMeasurementClient
 from measurement_client.logger import logger
 from event_manager.eventmanager import SintraEventManager
@@ -64,6 +66,11 @@ def create_parser():
         action='store_true',
         help='Fetch all saved measurements (ignores config file measurement_ids)'
     )
+    fetch_parser.add_argument(
+        '--since',
+        type=str,
+        help='Fetch results from the last N time units (e.g., 30m, 24h, 7d, 2w)'
+    )
     
     # Event management commands
     detect_parser = subparsers.add_parser('detect', help='Detect anomalies in measurement results')
@@ -89,6 +96,9 @@ def create_parser():
     
     # Plots command
     plots_parser = subparsers.add_parser('plots', help='Generate visualization plots for all measurements')
+    
+    # Status command
+    status_parser = subparsers.add_parser('status', help='Show current status of Sintra measurements and alerts')
     
     return parser
 
@@ -119,6 +129,39 @@ def handle_create_command(args):
         logger.error(f"Failed to create measurements: {e}")
         raise
 
+def parse_since_duration(since_str: str) -> int:
+    """Parse a duration string like '30m', '24h', '7d', or '2w' into a Unix timestamp.
+    
+    Supported units: m (minutes), h (hours), d (days), w (weeks).
+    Returns the Unix timestamp for (now - duration).
+    """
+    match = re.match(r'^(\d+)([mhdw])$', since_str.strip().lower())
+    if not match:
+        raise ValueError(
+            f"Invalid --since format: '{since_str}'. "
+            "Use format like '30m', '24h', '7d', or '2w'"
+        )
+    
+    value = int(match.group(1))
+    unit = match.group(2)
+    
+    if value <= 0:
+        raise ValueError(
+            f"Invalid --since value: '{since_str}'. "
+            "Duration must be greater than zero (e.g., '1h', not '0h')"
+        )
+    
+    unit_map = {
+        'm': 60,
+        'h': 60 * 60,
+        'd': 24 * 60 * 60,
+        'w': 7 * 24 * 60 * 60
+    }
+    
+    start_time = datetime.now(timezone.utc) - timedelta(seconds=value * unit_map[unit])
+    return int(start_time.timestamp())
+
+
 # This function handles the fetch measurements command
 # It fetches measurement results based on the provided configuration or specific measurement ID
 def handle_fetch_command(args):
@@ -126,6 +169,16 @@ def handle_fetch_command(args):
         logger.info("=== Fetching Measurement Results ===")
         
         client = SintraMeasurementClient(config_path=args.config)
+        
+        # Parse --since flag and set on client
+        if args.since:
+            try:
+                since_timestamp = parse_since_duration(args.since)
+                client.since_timestamp = since_timestamp
+                logger.info(f"Filtering results since: {datetime.fromtimestamp(since_timestamp, timezone.utc).isoformat().replace('+00:00', 'Z')}")
+            except ValueError as e:
+                logger.error(str(e))
+                return
         
         if args.all:
             # Fetch all saved measurements, ignore config
@@ -403,6 +456,85 @@ def plot():
     logger.info("Plot generation completed!")
     logger.info("Check 'visualization/plots/' directory for results")
 
+def handle_status_command(args):
+    """Handle the status command to show a quick overview of Sintra's state."""
+    try:
+        logger.info("=== Sintra Status ===")
+        
+        # Check fetched measurements
+        fetched_dir = Path("measurement_client/results/fetched_measurements")
+        created_dir = Path("measurement_client/results/created_measurements")
+        events_dir = Path("event_manager/results")
+        
+        # Created measurements
+        created_count = 0
+        if created_dir.exists():
+            created_count = len(list(created_dir.glob("measurement_*_info.json")))
+        logger.info(f"Created measurements: {created_count}")
+        
+        # Fetched measurements
+        fetched_count = 0
+        last_fetch_time = None
+        if fetched_dir.exists():
+            fetched_files = list(fetched_dir.glob("measurement_*_result.json"))
+            fetched_count = len(fetched_files)
+            if fetched_files:
+                # Get most recent fetch time from file modification time
+                latest_file = max(fetched_files, key=lambda f: f.stat().st_mtime)
+                last_fetch_time = datetime.fromtimestamp(
+                    latest_file.stat().st_mtime, tz=timezone.utc
+                ).strftime("%Y-%m-%d %H:%M:%S UTC")
+        
+        logger.info(f"Fetched measurements: {fetched_count}")
+        if last_fetch_time:
+            logger.info(f"Last fetch: {last_fetch_time}")
+        else:
+            logger.info("Last fetch: Never")
+        
+        # Anomaly detection status
+        event_count = 0
+        total_anomalies = 0
+        critical_alerts = 0
+        if events_dir.exists():
+            event_files = list(events_dir.glob("*.json"))
+            event_count = len(event_files)
+            
+            for event_file in event_files:
+                try:
+                    with open(event_file, "r") as f:
+                        data = json.load(f)
+                    events = data.get("events", [])
+                    total_anomalies += len(events)
+                    critical_alerts += sum(1 for e in events if e.get("severity") == "critical")
+                except (json.JSONDecodeError, IOError):
+                    pass
+        
+        if event_count > 0:
+            logger.info(f"Anomaly detection: Run ({event_count} file(s) analyzed)")
+        else:
+            logger.info("Anomaly detection: Not run yet")
+        
+        logger.info(f"Total anomalies: {total_anomalies}")
+        logger.info(f"Critical alerts: {critical_alerts}")
+        
+        # Overall health
+        if critical_alerts > 0:
+            logger.warning(f"[WARN] Network health: {critical_alerts} critical issue(s) detected")
+        elif total_anomalies > 0:
+            logger.info(f"Network health: {total_anomalies} anomaly(ies) detected, no critical issues")
+        elif event_count > 0:
+            logger.info("Network health: All clear [OK]")
+        else:
+            logger.info("Network health: Unknown (run 'sintra detect' first)")
+            
+    except OSError as e:
+        logger.error(f"Failed to show status: {e}")
+        return
+    except Exception:
+        logger.exception("Unexpected error while showing status")
+        raise
+
+
 # Main entry point for the Sintra
 def main():
     parser = create_parser()
@@ -432,6 +564,9 @@ def main():
         
         elif args.command == 'plots':
             handle_plots_command(args)
+        
+        elif args.command == 'status':
+            handle_status_command(args)
             
         elif len(sys.argv) > 1 and sys.argv[1] == "plot":
             plot()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Sintra test package

--- a/tests/test_anomaly_detection.py
+++ b/tests/test_anomaly_detection.py
@@ -1,0 +1,447 @@
+"""
+Unit tests for Sintra anomaly detection logic.
+
+Tests the core detection methods in SintraEventManager with synthetic
+measurement data to verify correct anomaly identification.
+"""
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from event_manager.eventmanager import SintraEventManager
+
+
+@pytest.fixture
+def temp_dirs(tmp_path):
+    """Create temporary directories for test isolation."""
+    fetched_dir = tmp_path / "fetched"
+    events_dir = tmp_path / "events"
+    baseline_dir = tmp_path / "baseline"
+    fetched_dir.mkdir()
+    events_dir.mkdir()
+    baseline_dir.mkdir()
+    return fetched_dir, events_dir, baseline_dir
+
+
+@pytest.fixture
+def event_manager(temp_dirs):
+    """Create an EventManager with temporary directories."""
+    fetched_dir, events_dir, baseline_dir = temp_dirs
+    return SintraEventManager(
+        fetched_results_dir=str(fetched_dir),
+        event_results_dir=str(events_dir),
+        baseline_dir=str(baseline_dir)
+    )
+
+
+def make_ping_result(probe_id, target, avg_rtt, packet_loss=0.0, rtts=None):
+    """Helper to create a synthetic ping measurement result."""
+    if rtts is None:
+        rtts = [] if avg_rtt is None else [avg_rtt] * 3  # 3 identical RTTs by default
+    return {
+        "probe_id": probe_id,
+        "measurement_type": "ping",
+        "target_address": target,
+        "latency_stats": {
+            "avg": avg_rtt if rtts else None,
+            "min": min(rtts) if rtts else None,
+            "max": max(rtts) if rtts else None,
+            "rtts": rtts
+        },
+        "packet_loss_percentage": packet_loss,
+        "packets_sent": max(len(rtts), 3),  # at least 3 packets sent
+        "packets_received": len(rtts)
+    }
+
+
+def make_traceroute_result(probe_id, target, hop_ips):
+    """Helper to create a synthetic traceroute measurement result."""
+    return {
+        "probe_id": probe_id,
+        "measurement_type": "traceroute",
+        "target_address": target,
+        "hops": [{"ip": ip} for ip in hop_ips],
+        "hops_count": len(hop_ips)
+    }
+
+
+def make_measurement_data(measurement_id, results):
+    """Wrap results into a measurement data structure."""
+    return {
+        "measurement_id": measurement_id,
+        "results": results
+    }
+
+
+# === Test: Latency Spike Detection ===
+
+class TestLatencySpikeDetection:
+    def test_high_latency_triggers_spike(self, event_manager):
+        """500ms latency should trigger a latency_spike (threshold=250ms)."""
+        data = make_measurement_data("test_1", [
+            make_ping_result("probe_1", "8.8.8.8", 500.0)
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "latency_spike" in anomaly_types
+
+    def test_normal_latency_no_spike(self, event_manager):
+        """50ms latency should NOT trigger a latency_spike."""
+        data = make_measurement_data("test_2", [
+            make_ping_result("probe_1", "8.8.8.8", 50.0)
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "latency_spike" not in anomaly_types
+
+
+# === Test: Packet Loss Detection ===
+
+class TestPacketLossDetection:
+    def test_high_packet_loss_triggers_alert(self, event_manager):
+        """25% packet loss should trigger a packet_loss event (threshold=10%)."""
+        data = make_measurement_data("test_3", [
+            make_ping_result("probe_1", "8.8.8.8", 100.0, packet_loss=25.0)
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "packet_loss" in anomaly_types
+
+    def test_unreachable_host_on_total_loss(self, event_manager):
+        """100% packet loss should trigger unreachable_host."""
+        data = make_measurement_data("test_4", [
+            make_ping_result("probe_1", "8.8.8.8", None, packet_loss=100.0, rtts=[])
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "unreachable_host" in anomaly_types
+
+
+# === Test: Jitter Spike Detection ===
+
+class TestJitterSpikeDetection:
+    def test_high_jitter_triggers_spike(self, event_manager):
+        """RTTs with high variance should trigger jitter_spike but not latency_spike."""
+        # RTTs: [10, 100, 10, 100, 10] -> stdev ~= 44ms > 15ms threshold
+        # avg=46ms is well below latency_spike threshold of 250ms
+        data = make_measurement_data("test_5", [
+            make_ping_result("probe_1", "8.8.8.8", 46.0, rtts=[10, 100, 10, 100, 10])
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "jitter_spike" in anomaly_types
+        assert "latency_spike" not in anomaly_types
+
+    def test_stable_rtts_no_jitter(self, event_manager):
+        """Stable RTTs should NOT trigger jitter_spike."""
+        data = make_measurement_data("test_6", [
+            make_ping_result("probe_1", "8.8.8.8", 50.0, rtts=[49, 50, 51, 50, 49])
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "jitter_spike" not in anomaly_types
+
+
+# === Test: Route Change Detection ===
+
+class TestRouteChangeDetection:
+    def test_route_change_detected(self, event_manager):
+        """Changed traceroute hops should trigger route_change on second run."""
+        target = "8.8.8.8"
+        
+        # First run: establish baseline
+        data1 = make_measurement_data("test_7", [
+            make_traceroute_result("probe_1", target, ["1.1.1.1", "2.2.2.2", "8.8.8.8"])
+        ])
+        event_manager.analyze_measurement(data1)
+        
+        # Second run: different route
+        data2 = make_measurement_data("test_7", [
+            make_traceroute_result("probe_1", target, ["1.1.1.1", "3.3.3.3", "8.8.8.8"])
+        ])
+        events = event_manager.analyze_measurement(data2)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "route_change" in anomaly_types
+
+
+# === Test: No False Positives ===
+
+class TestNoFalsePositives:
+    def test_normal_data_no_anomalies(self, event_manager):
+        """Normal, healthy measurement data should produce zero anomalies."""
+        data = make_measurement_data("test_8", [
+            make_ping_result("probe_1", "8.8.8.8", 30.0, packet_loss=0.0, rtts=[28, 30, 32]),
+            make_ping_result("probe_2", "8.8.8.8", 35.0, packet_loss=0.0, rtts=[33, 35, 37]),
+            make_ping_result("probe_3", "8.8.8.8", 25.0, packet_loss=0.0, rtts=[23, 25, 27]),
+        ])
+        events = event_manager.analyze_measurement(data)
+        assert len(events) == 0
+
+
+# === Test: Outlier Detection ===
+
+class TestOutlierDetection:
+    def test_outlier_probe_detected(self, event_manager):
+        """One probe with much higher latency than others should be flagged as outlier."""
+        data = make_measurement_data("test_9", [
+            make_ping_result("probe_1", "8.8.8.8", 30.0),
+            make_ping_result("probe_2", "8.8.8.8", 35.0),
+            make_ping_result("probe_3", "8.8.8.8", 25.0),
+            make_ping_result("probe_4", "8.8.8.8", 200.0),  # outlier: >2x average
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "outlier_probe_latency" in anomaly_types
+        
+        # Verify it's probe_4 that's flagged
+        outlier_events = [e for e in events if e["anomaly"] == "outlier_probe_latency"]
+        assert any(e["probe_id"] == "probe_4" for e in outlier_events)
+
+
+# === Test: Probe ID Type Consistency (Bug #3) ===
+
+class TestProbeIdConsistency:
+    def test_integer_probe_ids_handled(self, event_manager):
+        """Probe IDs as integers should work the same as strings."""
+        data = make_measurement_data("test_10", [
+            make_ping_result(12345, "8.8.8.8", 500.0)  # integer probe_id
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "latency_spike" in anomaly_types
+        # Verify probe_id is normalized to string on the specific event
+        latency_spike_event = next(e for e in events if e["anomaly"] == "latency_spike")
+        assert latency_spike_event["probe_id"] == "12345"
+
+
+# === Test: Correlated Routing Event ===
+
+class TestCorrelatedRoutingEvent:
+    def test_correlation_detects_spike_plus_route_change(self, event_manager):
+        """When latency_spike and route_change occur on same probe+target, 
+        a correlated_routing_event should be added."""
+        # Simulate events that would be produced by detection
+        fake_events = [
+            {"anomaly": "latency_spike", "probe_id": "probe_1", "target": "8.8.8.8"},
+            {"anomaly": "route_change", "probe_id": "probe_1", "target": "8.8.8.8"}
+        ]
+        correlated = event_manager._correlate_events(fake_events, "2026-01-01T00:00:00Z")
+        anomaly_types = [e["anomaly"] for e in correlated]
+        assert "correlated_routing_event" in anomaly_types
+        correlated_event = next(
+            e for e in correlated if e["anomaly"] == "correlated_routing_event"
+        )
+        assert correlated_event["description"] == (
+            "Latency spike likely caused by route change detected on the same probe"
+        )
+
+    def test_no_correlation_without_both_types(self, event_manager):
+        """If only latency_spike exists (no route_change), no correlation should be made."""
+        fake_events = [
+            {"anomaly": "latency_spike", "probe_id": "probe_1", "target": "8.8.8.8"},
+            {"anomaly": "packet_loss", "probe_id": "probe_1", "target": "8.8.8.8"}
+        ]
+        correlated = event_manager._correlate_events(fake_events, "2026-01-01T00:00:00Z")
+        assert len(correlated) == 0
+
+
+# === Test: Per-Target Thresholds ===
+
+class TestPerTargetThresholds:
+    def test_custom_threshold_triggers_spike(self, event_manager):
+        """A target with a lower custom threshold should trigger at lower latency."""
+        # Set a custom threshold for this target
+        event_manager.config["target_thresholds"] = {
+            "10.0.0.1": {"latency_spike_ms": 100.0}
+        }
+        # 150ms is under global 250ms but above custom 100ms
+        data = make_measurement_data("test_threshold", [
+            make_ping_result("probe_1", "10.0.0.1", 150.0)
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "latency_spike" in anomaly_types
+
+    def test_global_threshold_used_when_no_custom(self, event_manager):
+        """A target without a custom threshold should use the global 250ms default."""
+        event_manager.config["target_thresholds"] = {}
+        # 200ms is under global 250ms — should NOT trigger
+        data = make_measurement_data("test_global", [
+            make_ping_result("probe_1", "10.0.0.1", 200.0)
+        ])
+        events = event_manager.analyze_measurement(data)
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "latency_spike" not in anomaly_types
+
+
+# === Test: Rolling Baseline ===
+
+class TestRollingBaseline:
+    def test_baseline_requires_minimum_samples(self, event_manager):
+        """Baseline should return None until enough samples are stored.
+        
+        The baseline is computed from values stored *before* the current call,
+        so it takes min_samples+1 calls before a baseline is returned.
+        """
+        # Calls 1-3: build up the stored samples (baseline reads before appending)
+        for rtt in [100.0, 110.0, 120.0]:
+            baseline = event_manager._get_and_update_baseline_rtt("p1", "8.8.8.8", rtt)
+            assert baseline is None  # Not enough stored yet at read time
+
+        # Call 4: now 3 samples are stored, baseline should be available
+        baseline = event_manager._get_and_update_baseline_rtt("p1", "8.8.8.8", 130.0)
+        assert baseline is not None
+        assert abs(baseline - 110.0) < 1.0  # avg of [100, 110, 120] = 110
+
+    def test_baseline_none_target_returns_none(self, event_manager):
+        """If target_addr is None, baseline should return None without crashing."""
+        baseline = event_manager._get_and_update_baseline_rtt("p1", None, 100.0)
+        assert baseline is None
+
+
+# === Test: Webhook Alert ===
+
+class TestWebhookAlert:
+    @patch("event_manager.eventmanager.requests.post")
+    def test_webhook_disabled_does_not_send(self, mock_post, event_manager):
+        """When webhook is disabled, no HTTP request should be made."""
+        event_manager.config["webhook"] = {"enabled": False, "url": "", "timeout_seconds": 10}
+        event_manager.send_webhook_alert("test", [{"severity": "critical", "anomaly": "test"}])
+        mock_post.assert_not_called()
+
+    @patch("event_manager.eventmanager.requests.post")
+    def test_webhook_sends_on_critical_events(self, mock_post, event_manager):
+        """When webhook is enabled with critical events, POST should be called."""
+        mock_post.return_value = MagicMock(status_code=200)
+        event_manager.config["webhook"] = {
+            "enabled": True,
+            "url": "https://example.com/hook",
+            "timeout_seconds": 5
+        }
+        events = [{"severity": "critical", "anomaly": "latency_spike",
+                    "probe_id": "1", "target": "8.8.8.8"}]
+        event_manager.send_webhook_alert("test_msm", events)
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[1]["json"]["total_anomalies"] == 1
+
+    @patch("event_manager.eventmanager.requests.post")
+    def test_webhook_rejects_invalid_scheme(self, mock_post, event_manager):
+        """Webhook with ftp:// or other invalid schemes should be rejected."""
+        event_manager.config["webhook"] = {
+            "enabled": True,
+            "url": "ftp://example.com/hook",
+            "timeout_seconds": 5
+        }
+        event_manager.send_webhook_alert("test", [{"severity": "critical", "anomaly": "test"}])
+        mock_post.assert_not_called()
+
+    @patch("event_manager.eventmanager.requests.post")
+    def test_webhook_blocks_http_by_default(self, mock_post, event_manager):
+        """Plain HTTP should be blocked unless allow_insecure_http is set."""
+        event_manager.config["webhook"] = {
+            "enabled": True,
+            "url": "http://example.com/hook",
+            "timeout_seconds": 5
+        }
+        event_manager.send_webhook_alert("test", [{"severity": "critical", "anomaly": "test"}])
+        mock_post.assert_not_called()
+
+    @patch("event_manager.eventmanager.requests.post")
+    def test_webhook_allows_http_with_opt_in(self, mock_post, event_manager):
+        """Plain HTTP should be allowed when allow_insecure_http is true."""
+        mock_post.return_value = MagicMock(status_code=200)
+        event_manager.config["webhook"] = {
+            "enabled": True,
+            "url": "http://example.com/hook",
+            "timeout_seconds": 5,
+            "allow_insecure_http": True
+        }
+        event_manager.send_webhook_alert("test", [{"severity": "critical", "anomaly": "test"}])
+        mock_post.assert_called_once()
+
+    @patch("event_manager.eventmanager.requests.post")
+    def test_webhook_logs_non_2xx_response(self, mock_post, event_manager):
+        """Webhook returning non-2xx should not raise but should log warning."""
+        mock_post.return_value = MagicMock(status_code=500, text="Internal Server Error")
+        event_manager.config["webhook"] = {
+            "enabled": True,
+            "url": "https://example.com/hook",
+            "timeout_seconds": 5
+        }
+        # Should not raise
+        event_manager.send_webhook_alert("test", [{"severity": "critical", "anomaly": "test"}])
+        mock_post.assert_called_once()
+
+
+# === Test: Outlier with None Values ===
+
+class TestOutlierWithNone:
+    def test_outlier_detection_with_none_latencies(self, event_manager):
+        """Outlier detection should handle None values in latency lists gracefully."""
+        data = make_measurement_data("test_none", [
+            make_ping_result("probe_1", "8.8.8.8", None, packet_loss=100.0, rtts=[]),
+            make_ping_result("probe_2", "8.8.8.8", 30.0),
+            make_ping_result("probe_3", "8.8.8.8", 35.0),
+            make_ping_result("probe_4", "8.8.8.8", 200.0),
+        ])
+        # Should not raise despite None in latencies
+        events = event_manager.analyze_measurement(data)
+        assert isinstance(events, list)
+
+
+# === Test: Path Flapping Detection ===
+
+class TestPathFlapping:
+    def test_path_flapping_detected(self, event_manager):
+        """Frequent route changes should trigger path_flapping.
+        
+        Path flapping triggers when route_history length exceeds
+        path_flapping_window (default=3), so 4 runs are needed.
+        """
+        target = "8.8.8.8"
+        
+        # Run 4 analyses with alternating routes to trigger flapping
+        routes = [
+            ["1.1.1.1", "2.2.2.2", "8.8.8.8"],
+            ["1.1.1.1", "3.3.3.3", "8.8.8.8"],
+            ["1.1.1.1", "2.2.2.2", "8.8.8.8"],
+            ["1.1.1.1", "3.3.3.3", "8.8.8.8"],
+        ]
+        
+        events = []
+        for route in routes:
+            data = make_measurement_data("test_flap", [
+                make_traceroute_result("probe_1", target, route)
+            ])
+            events = event_manager.analyze_measurement(data)
+        
+        anomaly_types = [e["anomaly"] for e in events]
+        assert "path_flapping" in anomaly_types
+
+
+# === Test: Full Pipeline Correlation ===
+
+class TestFullPipelineCorrelation:
+    def test_correlation_through_analyze_measurement(self, event_manager):
+        """Full pipeline test: high latency + route change for same probe should
+        produce a correlated_routing_event via analyze_measurement."""
+        target = "8.8.8.8"
+        
+        # First run: establish baseline route
+        data1 = make_measurement_data("test_corr", [
+            make_ping_result("probe_1", target, 30.0),
+            make_traceroute_result("probe_1", target, ["1.1.1.1", "2.2.2.2", "8.8.8.8"])
+        ])
+        event_manager.analyze_measurement(data1)
+        
+        # Second run: high latency + changed route
+        data2 = make_measurement_data("test_corr", [
+            make_ping_result("probe_1", target, 500.0),
+            make_traceroute_result("probe_1", target, ["1.1.1.1", "3.3.3.3", "8.8.8.8"])
+        ])
+        events = event_manager.analyze_measurement(data2)
+        anomaly_types = [e["anomaly"] for e in events]
+        
+        assert "latency_spike" in anomaly_types
+        assert "route_change" in anomaly_types
+        assert "correlated_routing_event" in anomaly_types


### PR DESCRIPTION
## Implement All Proposed Enhancements (Bug Fixes, Improvements, New Features, and Tests)

This PR addresses all 11 items listed in the Sintra Proposed Enhancements document. The changes are grouped into 4 phases: fixing existing bugs first, then improving the detection engine, then adding new user-facing features, and finally adding unit tests to make sure everything works correctly.

### What changed at a glance

| Category | Count | Files Touched |
|----------|-------|---------------|
| Bug Fixes | 3 fixes | `client.py`, `eventmanager.py` |
| Detection Improvements | 3 improvements | `client.py`, `eventmanager.py`, `config.json` |
| New Features | 4 features | `sintra.py`, `eventmanager.py`, `anomaly_types.py`, `config.json` |
| Unit Tests | 10 test cases | `tests/test_anomaly_detection.py` |

---

## Phase 1: Bug Fixes

These are problems that already existed in the codebase and could cause silent failures or confusing behavior.

### 1. Removed Duplicate Processing Methods in `client.py`

**What was wrong:**
The file `measurement_client/client.py` had multiple methods that were doing the same thing - processing ping and traceroute results. Specifically:

- `_process_results()` and `_process_all_results()` were old methods that nobody was calling anymore. They were leftover code from before `_process_all_results_with_regions()` was written as their replacement.
- `_process_ping_result()` and `_process_traceroute_result()` were doing the exact same thing as `_process_ping_data()` and `_process_traceroute_data()`, just with a slightly different structure.

**Why this matters:**
Having duplicate code means if you fix a bug in one version, the other version still has the bug. It also makes the codebase harder to understand because you don't know which version is actually being used.

**What I did:**
- Deleted `_process_results()` and `_process_all_results()` since they were dead code (never called anywhere)
- Deleted `_process_ping_result()` and `_process_traceroute_result()` and moved their logic directly into `_process_measurement_result()` to keep everything in one place
- This removed about 140 lines of unnecessary code

---

### 2. Fixed a Logger Statement That Ran on Import

**What was wrong:**
In `client.py`, there was a line `logger.info("Creating measurements...")` sitting at the class level- meaning it was outside any method. In Python, code at the class level runs the moment the file is imported, not when you actually call a function.

So every time any part of Sintra imported the client module, you would see "Creating measurements..." in the logs even if you were just running `sintra alerts` or `sintra detect`. This was confusing because it looked like measurements were being created when they were not.

**What I did:**
Removed the stray line. The exact same log message already exists inside the `create_measurements()` method where it actually belongs.

---

### 3. Fixed Probe ID Type Mismatch in `eventmanager.py`

**What was wrong:**
RIPE Atlas returns probe IDs as integers (like `12345`), but different parts of the code sometimes treated them as strings (like `"12345"`). In Python, the integer `12345` and the string `"12345"` are completely different dictionary keys. So if one part of the code stored data under the integer key and another part tried to look it up using the string key, it would silently fail and return nothing.

This meant some probes could be completely skipped during anomaly detection without any error message telling you something went wrong.

**What I did:**
Added `probe_id = str(probe_id)` right after we read the probe ID from the results. This makes sure every probe ID is always a string throughout the entire detection pipeline, so there are no more silent lookup failures.

---

## Phase 2: Detection Improvements

These changes make the anomaly detection engine smarter and more reliable.

### 4. Added Exponential Backoff for API Calls

**What was the problem:**
When Sintra makes too many requests to the RIPE Atlas API in a short time, the API returns a 429 "Too Many Requests" error. Before this change, Sintra would just crash or skip the data when that happened.

**What I did:**
Added a helper method called `_request_with_backoff()` that automatically retries failed requests with increasing wait times:
- First retry: wait 2 seconds
- Second retry: wait 4 seconds  
- Third retry: wait 8 seconds

If the API is still rate-limiting after 3 retries, it logs an error and moves on instead of crashing. This was applied to all 3 places where Sintra calls the RIPE Atlas API:
- Getting measurement info
- Getting probe info (single)
- Getting probe info (batch)

---

### 5. Rolling Average for Baselines Instead of Single Value

**What was the problem:**
The baseline system is how Sintra knows what "normal" latency looks like for a specific probe. Before this change, the baseline was just the most recent RTT value. So if one measurement happened to be unusually high due to a temporary network blip, the baseline would jump to that high value and then future normal measurements would look unusually low by comparison.

**What I did:**
Changed the baseline to store the **last 10 RTT values** and use their average as the baseline. This smooths out temporary spikes and gives a much more stable picture of what "normal" looks like.

The baseline files now look like this:
```json
// Before (old format - just one value, gets replaced every time)
{"avg_rtt": 210.06}

// After (new format - keeps last 10 values, averages them)
{"rtts": [210.06, 195.3, 220.1, 180.5, ...], "avg_rtt": 201.49}
```

The code also handles the old format gracefully- if it finds a baseline file in the old format, it automatically converts it to the new format.

<img width="824" height="376" alt="3" src="https://github.com/user-attachments/assets/356a8c4e-458a-4c99-a4d7-aedd6ce62a42" />


---

### 6. Per-Target Latency Thresholds

**What was the problem:**
Sintra used a single global threshold (250ms) for all targets. But different targets have very different expected latencies. A server in your own country might normally respond in 30ms, while a server on another continent might normally take 200ms. Using 250ms as the threshold for both means you would never catch degradation on the nearby server (since even 200ms is under 250ms), and you might get false alarms on the far server.

**What I did:**
Added a `target_thresholds` section to `config.json` where you can set specific thresholds for specific target IPs:

```json
"target_thresholds": {
    "77.91.138.212": {"latency_spike_ms": 150.0},
    "103.68.48.6": {"latency_spike_ms": 200.0}
}
```

The detection code now checks if the target has a custom threshold first. If it does, it uses that. If not, it falls back to the global 250ms default.

---

## Phase 3: New Features

These are completely new capabilities added to Sintra.

### 7. New `sintra status` Command

**What it does:**
Gives you a quick overview of Sintra's current state without having to open any JSON files or run multiple commands. It tells you:
- How many measurements you have created and fetched
- When the last fetch happened
- Whether anomaly detection has been run
- How many anomalies and critical alerts exist
- An overall network health summary

**How to use it:**
```bash
python sintra.py status
```

<img width="657" height="341" alt="1" src="https://github.com/user-attachments/assets/be3d2b37-5ba6-4c9a-bbad-3eaa199d7c36" />



---

### 8. New `--since` Flag for the Fetch Command

**What it does:**
Lets you fetch only recent measurement results instead of downloading everything. This saves bandwidth and processing time, especially useful when you are running Sintra regularly and only care about the last few hours of data.

**How to use it:**
```bash
python sintra.py fetch --since 30m    # last 30 minutes
python sintra.py fetch --since 24h    # last 24 hours
python sintra.py fetch --since 7d     # last 7 days
python sintra.py fetch --since 2w     # last 2 weeks
```

If you type an invalid format, it tells you exactly what formats are supported instead of crashing.

<img width="776" height="470" alt="2" src="https://github.com/user-attachments/assets/fb139be7-736b-4f82-97a9-ce5249d3d90d" />


---

### 9. Measurement Correlation (Connecting Ping and Traceroute Data)

**What it does:**
Before this change, Sintra would report a latency spike and a route change as two completely separate events, even if they happened on the same probe at the same time. A human reading the alerts would have to manually connect the dots and figure out "oh, the latency went up because the route changed."

Now Sintra does that automatically. After detecting all anomalies, it groups them by probe and target. If it finds both a `latency_spike` and a `route_change` on the same probe going to the same target, it creates a new `correlated_routing_event` with the message: "Latency spike likely caused by route change detected on the same probe."

This moves Sintra from just reporting problems to actually helping you understand why they happened.

**Note:** This feature only activates when you have both ping and traceroute measurements targeting the same destination. With only ping measurements (which is what we have right now), there are no route changes to correlate with.

---

### 10. Webhook Alerts

**What it does:**
Before this change, the only way to know about network problems was to manually run `sintra alerts` and look at the output. With webhook alerts, Sintra can automatically send a notification to any service you want- Slack, Discord, Microsoft Teams, PagerDuty, or your own server - the moment it detects anomalies.

It sends a JSON payload containing the measurement ID, timestamp, list of anomalies with their types, affected probes, severity, and threshold values.

**How to set it up:**
In `event_manager/config.json`, set your webhook URL and enable it:
```json
"webhook": {
    "enabled": true,
    "url": "https://your-webhook-endpoint.com/alerts",
    "timeout_seconds": 10
}
```

Then just run `python sintra.py detect` and the alerts will be sent automatically.

**What the webhook receives:**
```json
{
    "measurement_id": "127745569",
    "timestamp": "2026-05-17T06:52:00Z",
    "total_anomalies": 6,
    "anomalies": [
        {
            "type": "latency_spike",
            "probe_id": "12345",
            "target": "103.68.48.6",
            "severity": "warning",
            "value": 415.3,
            "threshold": 250.0
        }
    ]
}
```

The webhook is disabled by default so it does not affect existing setups.

<img width="956" height="529" alt="5" src="https://github.com/user-attachments/assets/844fd612-0f89-4647-af82-317e22143c13" />


---

## Phase 4: Unit Tests

### 11. Added Unit Tests for Anomaly Detection

**Why this matters:**
Before this change, there were no automated tests for the anomaly detection logic. The only way to check if detection was working correctly was to run it on real data and manually verify the results. This is slow, unreliable, and makes it risky to change the detection code because you can not be sure you did not break something.

**What I added:**
Created `tests/test_anomaly_detection.py` with 10 test cases that feed synthetic measurement data into the event manager and verify it produces the correct anomaly events:

| Test Case | What It Checks |
|-----------|----------------|
| `test_high_latency_triggers_spike` | Feeds 500ms latency, expects a latency_spike event |
| `test_normal_latency_no_spike` | Feeds 50ms latency, expects no alert |
| `test_high_packet_loss_triggers_alert` | Feeds 25% packet loss, expects a packet_loss event |
| `test_unreachable_host_on_total_loss` | Feeds 100% packet loss, expects an unreachable_host event |
| `test_high_jitter_triggers_spike` | Feeds high variance RTTs, expects a jitter_spike event |
| `test_stable_rtts_no_jitter` | Feeds stable RTTs, expects no jitter alert |
| `test_route_change_detected` | Feeds changed hops on second run, expects a route_change event |
| `test_normal_data_no_anomalies` | Feeds completely normal data from 3 probes, expects zero events |
| `test_outlier_probe_detected` | Feeds 1 slow probe among 3 normal ones, expects outlier_probe_latency |
| `test_integer_probe_ids_handled` | Feeds integer probe IDs, expects them normalized to strings |

All 10 tests pass.

<img width="920" height="383" alt="4" src="https://github.com/user-attachments/assets/616bbfbc-8bda-4360-98c1-11f6a6c03c68" />


---

## All Files Changed

| File | What Changed |
|------|-------------|
| `measurement_client/client.py` | Removed ~140 lines of dead/duplicate code, removed stray logger call, added exponential backoff retry logic |
| `event_manager/eventmanager.py` | Fixed probe ID types, replaced single-value baselines with rolling averages, added per-target threshold lookup, added event correlation method, added webhook alert method |
| `event_manager/config.json` | Added `target_thresholds` section for per-target overrides, added `webhook` section for alert configuration |
| `event_manager/anomaly_types.py` | Added `correlated_routing_event` anomaly type definition |
| `sintra.py` | Added `status` subcommand and handler, added `--since` argument to fetch command with duration parser |
| `requirements.txt` | Added `pytest>=7.0.0` |
| `tests/__init__.py` | New file - test package init |
| `tests/test_anomaly_detection.py` | New file - 10 unit tests for anomaly detection |

## How to Test

```bash
# Install dependencies
pip install -r requirements.txt

# Run the full pipeline (should work exactly like before)
python sintra.py fetch
python sintra.py detect
python sintra.py alerts

# Try the new status command
python sintra.py status

# Try the new --since flag
python sintra.py fetch --since 24h

# Run all unit tests
pytest tests/ -v
```
@pradeeban Please take a look and let me know if any improvements are needed.
